### PR TITLE
Only show Abilities header if there are abilities

### DIFF
--- a/src/components/BackDetails.tsx
+++ b/src/components/BackDetails.tsx
@@ -7,7 +7,7 @@ const BackDetails = ({ unit }: { unit: Unit }) =>
   <>
     {unit.back && (
       <>
-        {"abilities" in unit.back && <>
+        {"abilities" in unit.back && unit.back.abilities.length > 0 && <>
           <h2>Special Abilities</h2>
 
           <AbilitiesAccordion abilities={unit.back.abilities} />

--- a/src/components/FrontDetails.tsx
+++ b/src/components/FrontDetails.tsx
@@ -4,7 +4,7 @@ import { AbilitiesAccordion } from "./AbilitiesAccordion.tsx";
 
 const FrontDetails = ({ unit }: { unit: Unit }) =>
   <>
-    {unit.front.abilities && <>
+    {unit.front.abilities.length > 0 && <>
       <h2>Special Abilities</h2>
 
       <AbilitiesAccordion abilities={unit.front.abilities} />


### PR DESCRIPTION
Some units were showing the "Abilities" header when they don't have any abilities. This PR fixes that.